### PR TITLE
BSD support

### DIFF
--- a/bspwmbar.c
+++ b/bspwmbar.c
@@ -2,7 +2,6 @@
 
 #define _XOPEN_SOURCE 700
 
-#include <alloca.h>
 #include <X11/Xatom.h>
 #include <X11/Xft/Xft.h>
 #include <X11/Xproto.h>

--- a/config.mk
+++ b/config.mk
@@ -4,8 +4,8 @@ PREFIX    ?= /usr/local
 DESTDIR   ?=
 MANPREFIX ?= $(PREFIX)/share/man
 
-CFLAGS  += -std=c99 -pedantic -Wall -Wextra -I/usr/include/freetype2
-LDFLAGS +=
+CFLAGS  += -std=c99 -pedantic -Wall -Wextra -I/usr/X11R6/include -I/usr/X11R6/include/freetype2
+LDFLAGS += -L/usr/X11R6/lib
 LDLIBS  += -lX11 -lfontconfig -lXft -lXrandr -lasound
 
 CC ?= cc


### PR DESCRIPTION
This is only from a openBSD perspective and not yet complete.
I was just trying to get it to compile without too much effort.

I adjusted C and LD flags because X11 and freetype locations are different on openBSD.
Removed alloca.h because alloca is present in stdlib.h on openBSD.

One porting issue is the use of epoll which is Linux specific. An alternative is [kqueue](https://en.wikipedia.org/wiki/Kqueue) which can be used on Mac OS and BSD.
Similar patching has been done from openBSD for wayland I think.

I'm neither a openBSD or C ace so my skills are limited, still happy to help though.