### PR TITLE
FreeBSD support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 *.o
+*.core
+*.orig
+*.rej
 Makefile
 compile_commands.json
 config.h

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.core
 *.orig
 *.rej
+*.gmon
 Makefile
 compile_commands.json
 config.h

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Currently required [nerd-fonts](https://github.com/ryanoasis/nerd-fonts)
 - [x] Emoji support (with color)
 - [x] Ligature support
 - [x] OpenBSD support
-- [ ] FreeBSD support
+- [x] FreeBSD support
 - [ ] Pulseaudio support (The priority is low because pulseaudio has alsa interface)
 
 ## Configure

--- a/alsa.c
+++ b/alsa.c
@@ -190,9 +190,10 @@ volume(draw_context_t *dc, module_option_t *opts)
 }
 
 void
-volume_ev(xcb_generic_event_t *ev)
+volume_ev(xcb_generic_event_t *ev, module_option_t *unused)
 {
 	xcb_button_press_event_t *button;
+	(void)unused;
 	switch (ev->response_type & ~0x80) {
 	case XCB_BUTTON_PRESS:
 		button = (xcb_button_press_event_t *)ev;

--- a/bspwmbar.h
+++ b/bspwmbar.h
@@ -137,6 +137,10 @@ typedef struct {
 	char *device;
 } module_backlight_t;
 
+typedef struct {
+	MODULE_BASE;
+} module_xbacklight_t;
+
 union _module_t {
 	module_any_t any;
 	module_systray_t tray;
@@ -151,6 +155,7 @@ union _module_t {
 	module_thermal_t thermal;
 	module_battery_t battery;
 	module_backlight_t backlight;
+	module_xbacklight_t xbacklight;
 };
 
 xcb_connection_t *xcb_connection();
@@ -169,6 +174,7 @@ void draw_padding_em(draw_context_t *, double);
 /* handler */
 void volume_ev(xcb_generic_event_t *, module_option_t *);
 void backlight_ev(xcb_generic_event_t *, module_option_t *);
+void xbacklight_ev(xcb_generic_event_t *, module_option_t *);
 
 /* modules */
 void text(draw_context_t *, module_option_t *);
@@ -183,6 +189,7 @@ void memgraph(draw_context_t *, module_option_t *);
 void systray(draw_context_t *, module_option_t *);
 void battery(draw_context_t *, module_option_t *);
 void backlight(draw_context_t *, module_option_t *);
+void xbacklight(draw_context_t *, module_option_t *);
 
 /* temporary buffer */
 extern char buf[1024];

--- a/bspwmbar.h
+++ b/bspwmbar.h
@@ -67,6 +67,12 @@ typedef struct {
 typedef struct {
 	MODULE_BASE;
 
+	char *device;
+} module_mixer_t;
+
+typedef struct {
+	MODULE_BASE;
+
 	char *focused;
 	char *unfocused;
 	char *fg;
@@ -147,6 +153,7 @@ union _module_t {
 	module_datetime_t date;
 	module_filesystem_t fs;
 	module_volume_t vol;
+	module_mixer_t mixer;
 	module_desktop_t desk;
 	module_text_t text;
 	module_graph_t cpu;
@@ -173,6 +180,7 @@ void draw_padding_em(draw_context_t *, double);
 
 /* handler */
 void volume_ev(xcb_generic_event_t *, module_option_t *);
+void mixer_ev(xcb_generic_event_t *, module_option_t *);
 void backlight_ev(xcb_generic_event_t *, module_option_t *);
 void xbacklight_ev(xcb_generic_event_t *, module_option_t *);
 
@@ -183,6 +191,7 @@ void windowtitle(draw_context_t *, module_option_t *);
 void filesystem(draw_context_t *, module_option_t *);
 void thermal(draw_context_t *, module_option_t *);
 void volume(draw_context_t *, module_option_t *);
+void mixer(draw_context_t *, module_option_t *);
 void datetime(draw_context_t *, module_option_t *);
 void cpugraph(draw_context_t *, module_option_t *);
 void memgraph(draw_context_t *, module_option_t *);

--- a/bspwmbar.h
+++ b/bspwmbar.h
@@ -32,7 +32,7 @@ typedef module_t module_option_t;
 /* Draw context */
 typedef struct _draw_context_t draw_context_t;
 typedef void (* module_handler_t)(draw_context_t *, module_option_t *);
-typedef void (* event_handler_t)(xcb_generic_event_t *);
+typedef void (* event_handler_t)(xcb_generic_event_t *, module_option_t *);
 
 /* Poll */
 typedef int (* poll_init_handler_t)();
@@ -133,6 +133,8 @@ typedef struct {
 
 typedef struct {
 	MODULE_BASE;
+
+	char *device;
 } module_backlight_t;
 
 union _module_t {
@@ -165,8 +167,8 @@ void draw_bargraph(draw_context_t *, const char *, graph_item_t *, int);
 void draw_padding_em(draw_context_t *, double);
 
 /* handler */
-void volume_ev(xcb_generic_event_t *);
-void backlight_ev(xcb_generic_event_t *);
+void volume_ev(xcb_generic_event_t *, module_option_t *);
+void backlight_ev(xcb_generic_event_t *, module_option_t *);
 
 /* modules */
 void text(draw_context_t *, module_option_t *);

--- a/config.def.h
+++ b/config.def.h
@@ -100,6 +100,7 @@ module_t right_modules[] = {
 	// 		.handler = backlight_ev,
 	// 		.prefix = "盛 ",
 	// 		.suffix = "％",
+	// 		.device = "/dev/backlight/backlight0",
 	// 	},
 	// },
 	{ /* master playback volume */

--- a/config.def.h
+++ b/config.def.h
@@ -94,13 +94,21 @@ module_t right_modules[] = {
 	// 		.path = "/sys/class/power_supply/BAT0/uevent",
 	// 	},
 	// },
-	// { /* backlight */
+	// { /* device-based backlight */
 	// 	.backlight = {
 	// 		.func = backlight,
 	// 		.handler = backlight_ev,
 	// 		.prefix = "盛 ",
 	// 		.suffix = "％",
 	// 		.device = "/dev/backlight/backlight0",
+	// 	},
+	// },
+	// { /* x-based backlight */
+	// 	.xbacklight = {
+	// 		.func = xbacklight,
+	// 		.handler = xbacklight_ev,
+	// 		.prefix = "盛 ",
+	// 		.suffix = "％",
 	// 	},
 	// },
 	{ /* master playback volume */

--- a/configure
+++ b/configure
@@ -51,7 +51,7 @@ case $(uname -s) in
     MODS="${MODS} volume"
     ;;
   FreeBSD)
-    MODS="${MODS}"
+    MODS="${MODS} mixer"
     ;;
 esac
 

--- a/configure
+++ b/configure
@@ -50,6 +50,9 @@ case $(uname -s) in
   OpenBSD)
     MODS="${MODS} volume"
     ;;
+  FreeBSD)
+    MODS="${MODS}"
+    ;;
 esac
 
 DEPCFLAGS="$("${PKGCONFIG}" --cflags "${DEPS}")"

--- a/configure
+++ b/configure
@@ -7,7 +7,7 @@ PREFIX=/usr/local
 
 PKGCONFIG='pkg-config'
 DEPS='xcb xcb-ewmh xcb-util xcb-randr xcb-shm xcb-renderutil cairo harfbuzz fontconfig'
-MODS='bspwm cpu memory disk thermal datetime battery backlight'
+MODS='bspwm cpu memory disk thermal datetime battery backlight xbacklight'
 
 # debug flags
 CFLAGS='-Os -Wall -Wextra -pedantic -pipe -fstack-protector-strong -fno-plt -DNDEBUG'

--- a/memory.c
+++ b/memory.c
@@ -5,8 +5,13 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-#if defined(__OpenBSD__)
+#if defined(__OpenBSD__) || defined(__FreeBSD__)
 # include <sys/sysctl.h>
+#endif
+#if defined(__FreeBSD__)
+# include <sys/types.h>
+# include <sys/resource.h>
+# include <vm/vm_param.h>
 #endif
 
 #include "bspwmbar.h"
@@ -19,6 +24,13 @@ typedef struct {
 } MemInfo;
 #elif defined(__OpenBSD__)
 typedef struct uvmexp MemInfo;
+#elif defined(__FreeBSD__)
+typedef struct {
+	uint64_t total;
+	uint64_t free;
+	uint64_t inactive;
+	uint64_t cache;
+} MemInfo;
 #endif
 
 /* functions */
@@ -39,6 +51,8 @@ calc_used(MemInfo mem)
 	return (double)(mem.total - mem.available) / mem.total;
 #elif defined(__OpenBSD__)
 	return (double)mem.active / mem.npages;
+#elif defined(__FreeBSD__)
+	return (double)(mem.inactive + mem.free + mem.cache) / mem.total;
 #endif
 }
 
@@ -69,6 +83,16 @@ mem_perc()
 	int mib[] = { CTL_VM, VM_UVMEXP };
 	size_t len = sizeof(a);
 	if (sysctl(mib, 2, &a, &len, NULL, 0) < 0)
+		return 0;
+#elif defined(__FreeBSD__)
+	size_t len = sizeof(a.total); // all members are uint64_t, probably won't change
+	if (sysctlbyname("hw.physmem", &a.total, &len, NULL, 0) < 0)
+		return 0;
+	if (sysctlbyname("vm.stats.vm.v_free_count", &a.free, &len, NULL, 0) < 0)
+		return 0;
+	if (sysctlbyname("vm.stats.vm.v_inactive_count", &a.inactive, &len, NULL, 0) < 0)
+		return 0;
+	if (sysctlbyname("vm.stats.vm.v_cache_count", &a.cache, &len, NULL, 0) < 0)
 		return 0;
 #endif
 	return calc_used(a);

--- a/memory.c
+++ b/memory.c
@@ -5,13 +5,13 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-#if defined(__OpenBSD__) || defined(__FreeBSD__)
-# include <sys/sysctl.h>
-#endif
 #if defined(__FreeBSD__)
 # include <sys/types.h>
 # include <sys/resource.h>
 # include <vm/vm_param.h>
+#endif
+#if defined(__OpenBSD__) || defined(__FreeBSD__)
+# include <sys/sysctl.h>
 #endif
 
 #include "bspwmbar.h"

--- a/mixer.c
+++ b/mixer.c
@@ -1,0 +1,111 @@
+/* See LICENSE file for copyright and license details. */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/soundcard.h>
+#include <xcb/xcb.h>
+
+#include "util.h"
+#include "bspwmbar.h"
+
+typedef struct {
+	int8_t lvol;
+	int8_t rvol;
+} mixer_t;
+
+static bool mixer_load(const char *, mixer_t *);
+static void mixer_set(int8_t);
+
+void
+mixer(draw_context_t *dc, module_option_t *opts)
+{
+	mixer_t mixer;
+
+	if (!mixer_load(opts->mixer.device, &mixer))
+		return;
+
+	sprintf(buf, "%s%i%s", opts->mixer.prefix, BIGGER(mixer.lvol, mixer.rvol), opts->mixer.suffix);
+	draw_text(dc, buf);
+}
+
+static char *device = NULL;
+static int fd = -1;
+
+bool
+mixer_load(const char *devname, mixer_t *mixer)
+{
+	int vol;
+
+	if (device == NULL) {
+		if ((device = strdup(devname)) == NULL || *device == '\0')
+			device = "/dev/mixer";
+	}
+
+	if (fd < 0 && (fd = open(device, O_RDWR)) < 0) {
+		return false;
+	}
+
+	if (ioctl(fd, SOUND_MIXER_READ_VOLUME, &vol) < 0) {
+		close(fd);
+		fd = -1;
+		return false;
+	}
+
+	mixer->lvol = vol & 0x7F;
+	mixer->rvol = (vol >> 8) & 0x7F;
+
+	return true;
+}
+
+void
+mixer_set(int8_t vol)
+{
+	if (fd < 0)
+		return;
+
+	int rl = vol | (vol << 8);
+	if (ioctl(fd, SOUND_MIXER_WRITE_VOLUME, &rl) < 0) {
+		close(fd);
+		fd = -1;
+		return;
+	}
+}
+
+void
+mixer_ev(xcb_generic_event_t *ev, module_option_t *opts)
+{
+	mixer_t mixer;
+	xcb_button_press_event_t *button;
+	double cur;
+	const double step = 6;
+
+	if (!mixer_load(opts->mixer.device, &mixer))
+		return;
+
+	cur = BIGGER(mixer.lvol, mixer.rvol);
+
+	switch (ev->response_type & ~0x80) {
+	case XCB_BUTTON_PRESS:
+		button = (xcb_button_press_event_t *)ev;
+		switch (button->detail) {
+		case XCB_BUTTON_INDEX_4:
+			cur = (cur / step) * step + step;
+			if (cur > 100)
+				cur = 100;
+			mixer_set((int8_t)cur);
+			break;
+		case XCB_BUTTON_INDEX_5:
+			cur = (cur / step) * step - step;
+			if (cur < 0)
+				cur = 0;
+			mixer_set((int8_t)cur);
+			break;
+		}
+		break;
+	}
+}
+

--- a/thermal.c
+++ b/thermal.c
@@ -5,6 +5,10 @@
 #include <stdint.h>
 #include <unistd.h>
 #include <time.h>
+#if defined(__OpenBSD__) || defined(__FreeBSD__)
+# include <sys/types.h>
+# include <sys/sysctl.h>
+#endif
 
 #include "bspwmbar.h"
 #include "util.h"
@@ -12,6 +16,7 @@
 void
 thermal(draw_context_t *dc, module_option_t *opts)
 {
+#if defined(__linux)
 	static time_t prevtime;
 	static unsigned long temp;
 	static int thermal_found = -1;
@@ -38,7 +43,26 @@ DRAW_THERMAL:
 		opts->thermal.prefix = "";
 	if (!opts->thermal.suffix)
 		opts->thermal.suffix = "";
+
 	sprintf(buf, "%s%lu%s", opts->thermal.prefix, temp / 1000,
 	        opts->thermal.suffix);
+#elif defined(__OpenBSD__)
+	//int mib[3] = { HW_SENSORS, 0 };
+	sprintf(buf, "%sNOIMPL%s", opts->thermal.prefix, opts->thermal.suffix);
+#elif defined(__FreeBSD__)
+	int temp;
+	size_t templen = sizeof(temp);
+
+	char ctlname[64] = { 0 };
+	sprintf(ctlname, "hw.acpi.thermal.%s.temperature", opts->thermal.sensor);
+	if (sysctlbyname(ctlname, &temp, &templen, NULL, 0) < 0) {
+		return;
+	}
+
+	double atemp = (double)temp / 10 - 273.15;
+	sprintf(buf, "%s%.*f%s", opts->thermal.prefix, 1, atemp,
+	        opts->thermal.suffix);
+#endif
+
 	draw_text(dc, buf);
 }

--- a/volume.c
+++ b/volume.c
@@ -153,10 +153,11 @@ set_volume(int fd, int vol)
 }
 
 void
-volume_ev(xcb_generic_event_t *ev)
+volume_ev(xcb_generic_event_t *ev, module_option_t *unused)
 {
 	xcb_button_press_event_t *button;
 	int fd, vol;
+	(void)unused;
 
 	if ((fd = open(file, O_RDWR)) < 0)
 		die("volume: failed to open %s\n", file);

--- a/xbacklight.c
+++ b/xbacklight.c
@@ -1,0 +1,160 @@
+/* See LICENSE file for copyright and license details. */
+
+#if defined(__linux)
+# include <alloca.h>
+#endif
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdbool.h>
+
+#include <xcb/xcb.h>
+#include <xcb/randr.h>
+
+#include "bspwmbar.h"
+#include "util.h"
+
+typedef struct {
+	int32_t min;
+	int32_t max;
+	int32_t cur;
+} xbacklight_t;
+
+static bool init_atom(xcb_connection_t *);
+static bool xbacklight_load(xbacklight_t *, xcb_connection_t *);
+static bool xbacklight_load_info(xcb_connection_t *, xcb_randr_output_t, xbacklight_t *);
+static void xbacklight_set(xcb_connection_t *, xcb_randr_output_t, int32_t);
+
+static xcb_atom_t atom_backlight;
+static xcb_randr_output_t output_cache;
+
+void
+xbacklight(draw_context_t *dc, module_option_t *opts)
+{
+	xbacklight_t backlight = { 0 };
+	uint32_t blightness = 0;
+
+	if (!xbacklight_load(&backlight, xcb_connection()))
+		return;
+
+	blightness = (double)(backlight.cur - backlight.min) * 100 / (double)(backlight.max - backlight.min);
+
+	sprintf(buf, "%s%d%s", opts->backlight.prefix, blightness, opts->backlight.suffix);
+	draw_text(dc, buf);
+}
+
+bool
+xbacklight_load(xbacklight_t *backlight, xcb_connection_t *xcb)
+{
+	size_t i;
+	xcb_randr_get_screen_resources_reply_t *screen_reply;
+	xcb_randr_output_t *outputs;
+
+	xcb_screen_t *scr = xcb_setup_roots_iterator(xcb_get_setup(xcb)).data;
+
+	screen_reply = xcb_randr_get_screen_resources_reply(xcb, xcb_randr_get_screen_resources(xcb, scr->root), NULL);
+	outputs = xcb_randr_get_screen_resources_outputs(screen_reply);
+
+	for (i = 0; i < screen_reply->num_outputs; i++) {
+		if (xbacklight_load_info(xcb, outputs[i], backlight)) {
+			output_cache = outputs[i];
+			break;
+		}
+	}
+	free(screen_reply);
+
+	return true;
+}
+
+bool
+xbacklight_load_info(xcb_connection_t *xcb, xcb_randr_output_t output, xbacklight_t *backlight)
+{
+	xcb_randr_get_output_property_reply_t *prop_reply;
+	xcb_randr_query_output_property_reply_t *query_reply;
+	int32_t cur, *values;
+
+	/* get atom for backlight */
+	if (!atom_backlight && !init_atom(xcb))
+		return false;
+
+	prop_reply = xcb_randr_get_output_property_reply(xcb, xcb_randr_get_output_property(xcb, output, atom_backlight, XCB_ATOM_NONE, 0, 4, 0, 0), NULL);
+	if (!prop_reply)
+		return false;
+	cur = *((int32_t *)xcb_randr_get_output_property_data(prop_reply));
+	free(prop_reply);
+
+	query_reply = xcb_randr_query_output_property_reply(xcb, xcb_randr_query_output_property(xcb, output, atom_backlight), NULL);
+	if (!query_reply)
+		return false;
+	if (query_reply->range && xcb_randr_query_output_property_valid_values_length(query_reply) == 2) {
+		backlight->cur = cur;
+		values = xcb_randr_query_output_property_valid_values(query_reply);
+
+		backlight->min = values[0];
+		backlight->max = values[1];
+	}
+	free(query_reply);
+
+	return true;
+}
+
+void
+xbacklight_set(xcb_connection_t *xcb, xcb_randr_output_t output, int32_t value)
+{
+	/* get atom for backlight */
+	if (!atom_backlight && !init_atom(xcb))
+		return;
+
+	xcb_randr_change_output_property(xcb, output, atom_backlight, XCB_ATOM_INTEGER, 32, XCB_PROP_MODE_REPLACE, 1, (unsigned char *)&value);
+}
+
+void
+xbacklight_ev(xcb_generic_event_t *ev, module_option_t *unused)
+{
+	xbacklight_t backlight;
+	xcb_button_press_event_t *button;
+	double cur, step;
+	(void)unused;
+
+	xcb_connection_t *xcb = xcb_connection();
+	if (!xbacklight_load(&backlight, xcb))
+		return;
+
+	cur = (backlight.cur - backlight.min);
+	step = (double)(backlight.max - backlight.min) * 0.05 + 1;
+
+	switch (ev->response_type & ~0x80) {
+	case XCB_BUTTON_PRESS:
+		button = (xcb_button_press_event_t *)ev;
+		switch (button->detail) {
+		case XCB_BUTTON_INDEX_4:
+			cur = (cur / step) * step + step;
+			if (cur > backlight.max)
+				cur = backlight.max;
+			xbacklight_set(xcb, output_cache, cur);
+			break;
+		case XCB_BUTTON_INDEX_5:
+			cur = (cur / step) * step - step;
+			if (cur < backlight.min)
+				cur = backlight.min;
+			xbacklight_set(xcb, output_cache, cur);
+			break;
+		}
+		break;
+	}
+}
+
+bool
+init_atom(xcb_connection_t *xcb)
+{
+	xcb_intern_atom_reply_t *backlight_reply;
+
+	backlight_reply = xcb_intern_atom_reply(xcb, xcb_intern_atom(xcb, true, strlen("Backlight"), "Backlight"), NULL);
+	if (!backlight_reply)
+		return false;
+
+	atom_backlight = backlight_reply->atom;
+	free(backlight_reply);
+
+	return true;
+}


### PR DESCRIPTION
PR adds support for FreeBSD.
I moved the original backlight module to `xbacklight.c`  and implemented a new one that doesn't rely on XRandR as I couldn't get it to work under freebsd on my hardware.